### PR TITLE
Fix: Add viewport constraints with hybrid positioning (v2.1.2)

### DIFF
--- a/jamf_auto_refresh.js
+++ b/jamf_auto_refresh.js
@@ -458,10 +458,15 @@
     const leftPx = parseInt(String(left).replace('px', ''), 10) || 0;
     
     // Calculate constraint boundaries
-    const maxBottom = viewportHeight - MIN_VISIBLE;
+    // Bottom edge: widget bottom must be at least MIN_VISIBLE from viewport bottom
     const minBottom = MIN_VISIBLE;
-    const maxLeft = viewportWidth - widgetWidth - MIN_VISIBLE;
+    // Top edge: widget top (bottom + height) must be at least MIN_VISIBLE from viewport top
+    const maxBottom = viewportHeight - widgetHeight - MIN_VISIBLE;
+    
+    // Left edge: widget left must be at least MIN_VISIBLE from viewport left
     const minLeft = MIN_VISIBLE;
+    // Right edge: widget right (left + width) must be at least MIN_VISIBLE from viewport right
+    const maxLeft = viewportWidth - widgetWidth - MIN_VISIBLE;
     
     // During drag, just apply simple constraints
     if (duringDrag) {
@@ -492,7 +497,7 @@
       let newBottom = bottomPercent * viewportHeight;
       let newLeft = leftPercent * viewportWidth;
       
-      // Apply constraints to ensure visibility
+      // Apply constraints to ensure ENTIRE widget is visible
       newBottom = Math.max(minBottom, Math.min(maxBottom, newBottom));
       newLeft = Math.max(minLeft, Math.min(maxLeft, newLeft));
       


### PR DESCRIPTION
## 🎯 Purpose

Fixes #3 - Prevents widget from becoming inaccessible when browser window is resized.

## 🔧 Changes

Implements a smart hybrid positioning algorithm that:

- ✅ **Prevents off-screen positioning** - Widget always stays within viewport bounds
- ✅ **Maintains relative position** - Center-positioned widgets keep their relative location during resize
- ✅ **Preserves edge positioning** - Widgets at edges stay at edges when window resizes
- ✅ **Real-time drag constraints** - Cannot drag widget completely off-screen
- ✅ **Auto-corrects invalid positions** - Fixes extreme/invalid saved positions on load

## 📝 Implementation Details

### New Function: `constrainToViewport()`
- **Hybrid algorithm**: Detects if widget is at edge (5px tolerance) or freely positioned
- **Smart scaling**: Maintains relative position (%) for center widgets
- **Edge preservation**: Re-constrains at edges without scaling
- **Full visibility**: Ensures entire widget (width + height) is visible
- **Minimum padding**: Guarantees 20px visible on all sides

### Updated Functions
1. **`drag()`** - Real-time constraint checking during drag
2. **`loadPosition()`** - Validates saved positions against current viewport
3. **`createUI()`** - Post-render validation for edge cases

### New Event Listener
- **Window resize handler** with 250ms debounce
- Automatically repositions widget if it goes off-screen
- Saves new position after resize
- Protected by `window.__jamfAutoRefreshResizeListener` flag

## 🎨 How It Works

### Scenario 1: Widget in Center
```
Widget at 50% from left on 1920px screen = 960px left
Window resizes to 1024px wide
Widget moves to 50% of 1024px = 512px left
✅ Maintains same relative position
```

### Scenario 2: Widget at Edge
```
Widget at right edge on 1920px screen
Window resizes to 1024px wide
Widget detected as "at edge" (within 5px tolerance)
Widget re-constrains to new right edge
✅ Stays at edge, doesn't scale
```

### Scenario 3: During Drag
```
User drags widget toward edge
Simple constraint applied (no scaling)
Widget stops at 20px from any edge
✅ Smooth bounded dragging
```

## 📊 Code Statistics

- **Version**: 2.1.1 → 2.1.2
- **Files modified**: 1 (jamf_auto_refresh.js)
- **Lines added**: 158
- **Lines removed**: 9
- **Net change**: +149 lines
- **Functions added**: 1 (`constrainToViewport`)
- **Functions modified**: 3 (`drag`, `loadPosition`, `createUI`)
- **Event listeners added**: 1 (window.resize)

## 🧪 Testing

### Quick Test
1. Install script from this branch
2. Position widget in center → resize window → maintains relative position ✅
3. Position widget at edge → resize window → stays at edge ✅
4. Try dragging off screen → stops at 20px boundary ✅

### Comprehensive Testing
See [TESTING_ISSUE_3.md](https://github.com/BetterCallSaulAtlas/jamf-auto-refresh/blob/fix/issue-3-viewport-constraints/TESTING_ISSUE_3.md) for detailed test scenarios covering:
- Basic drag constraints
- Relative position maintenance
- Edge detection
- Extreme positions
- Window resize behavior
- Mobile/responsive sizes
- SPA navigation persistence
- Rapid resizing performance

## ✨ Key Features

✅ Widget always stays within viewport (20px minimum visible on all sides)  
✅ Maintains relative position during window resize  
✅ Smart edge detection for widgets at viewport boundaries  
✅ Real-time drag constraints prevent going off-screen  
✅ Debounced resize handling (250ms) for smooth performance  
✅ Auto-corrects extreme/invalid saved positions  
✅ Backward compatible - no breaking changes  
✅ Protected by window flags (prevents duplicate listeners)

## 🐛 Bug Fixes

### Commit 1: Initial Implementation
- Added hybrid constraint algorithm
- Window resize handling with debounce
- Position validation on load
- Real-time drag constraints

### Commit 2: Full Widget Visibility
- Fixed `maxBottom` calculation to account for widget height
- Ensures **entire widget** is visible, not just the bottom edge
- Changed: `maxBottom = viewportHeight - widgetHeight - MIN_VISIBLE`

## 🔄 Breaking Changes

None - this is a backward-compatible bug fix.

## 📦 Release Notes

Will be included in **v2.1.2** release with:
- Comprehensive changelog
- Migration guide (none needed)
- Testing documentation

## ✅ Checklist

- [x] Code follows project standards
- [x] Changes are backward compatible
- [x] No breaking changes
- [x] Version number updated (2.1.2)
- [x] Testing guide provided
- [x] Issue #3 linked
- [x] Commits are descriptive
- [x] Branch is up to date with main

## 📸 Testing Screenshots

Tested and confirmed working:
- Widget stays fully visible during resize
- Drag constraints prevent off-screen positioning
- Relative position maintained for center widgets
- Edge widgets stay at edges

---

**Ready for review and merge!** 🚀