### PR TITLE
Fix mini mode state restoration on page refresh

### DIFF
--- a/jamf_auto_refresh.js
+++ b/jamf_auto_refresh.js
@@ -1294,10 +1294,17 @@
   }
 
   // Toggle between mini and full mode
-  function toggleMiniMode() {
+  // @param {boolean} [forceMode] - Optional: true for mini mode, false for full mode, undefined to toggle
+  function toggleMiniMode(forceMode) {
     if (!refreshContainer) return;
     
-    isMiniMode = !isMiniMode;
+    // If forceMode is provided, use it; otherwise toggle
+    if (forceMode !== undefined) {
+      isMiniMode = forceMode;
+    } else {
+      isMiniMode = !isMiniMode;
+    }
+    
     localStorage.setItem(STORAGE_KEY_MINI_MODE, String(isMiniMode));
     
     if (isMiniMode) {
@@ -1771,7 +1778,7 @@
     if (isMiniMode) {
       // Apply mini mode without animation on initial load
       refreshContainer.style.transition = 'none';
-      toggleMiniMode();
+      toggleMiniMode(true); // Force mini mode instead of toggling
       // Re-enable transitions after a frame
       requestAnimationFrame(() => {
         refreshContainer.style.transition = 'all 0.2s ease';
@@ -1780,6 +1787,8 @@
       // Add transition for future toggles
       refreshContainer.style.transition = 'all 0.2s ease';
     }
+    
+    console.log('[Jamf Auto-Refresh] Mini mode restored:', isMiniMode);
     
     // Final validation after widget is in DOM and has dimensions
     // This ensures the position is correct based on actual rendered size


### PR DESCRIPTION
## 🐛 Bug Fix

Fixes #8 - Mini mode now properly restores its state after page refresh.

## 📋 Problem

When the widget was in mini mode and a page refresh occurred (manual or auto-refresh), the widget would expand back to full mode instead of staying minimized. This defeated the purpose of the mini mode feature as users had to manually minimize the widget again after every refresh.

## 🔍 Root Cause

The issue was in the state restoration logic. When `isMiniMode` was loaded as `true` from localStorage, the code called `toggleMiniMode()` which **toggled** the state:

```javascript
isMiniMode = !isMiniMode; // true becomes false!
```

So the widget ended up in full mode instead of mini mode.

## ✅ Solution

Modified the `toggleMiniMode()` function to accept an optional `forceMode` parameter:
- **`forceMode = true`** - Forces mini mode
- **`forceMode = false`** - Forces full mode  
- **`forceMode = undefined`** - Toggles (original behavior)

Updated the restoration logic to call `toggleMiniMode(true)` instead of `toggleMiniMode()`, which now explicitly sets mini mode instead of toggling.

## 🧪 Testing

**Before fix:**
1. ✅ Load page → Widget in full mode
2. ✅ Click minimize (−) → Widget in mini mode
3. ❌ Refresh page → Widget in full mode (BUG!)

**After fix:**
1. ✅ Load page → Widget in full mode
2. ✅ Click minimize (−) → Widget in mini mode
3. ✅ Refresh page → Widget stays in mini mode ✨

**Backward Compatibility:**
- ✅ Manual minimize/expand still works (uses toggle behavior)
- ✅ Click handlers unchanged
- ✅ No breaking changes to existing functionality

## 📊 Impact

- **Files changed**: 1 (`jamf_auto_refresh.js`)
- **Lines added**: 12
- **Lines removed**: 3
- **Net change**: +9 lines

---

**Ready for review and merge!** 🚀